### PR TITLE
Expose an API via require('writ')

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ destination directory:
 
     writ "src/*.md" --dir build
 
+There is also an API, which can be accessed via `require("writ")`, with the following exports:
+
+* `compile(sourceString, langExt)` -- takes a markdown string and returns the extracted code string
+* `writ(sourcePath, outputDir)` -- read the file at `sourcePath` and write the compiled version to `outputDir`.  The output filename is the source name minus `.md` or `.markdown`, and the language for compiling is taken from the second extension, if any.  (e.g. `foo.js.md` is assumed to be JavaScript.)
+* `main(argv)` -- the command-line tool, complete with argument parsing; be sure to include two dummy arguments at the front to simulate `process.argv`.
+* `Source` -- the class that's used to take parsed markdown and extract/assemble code blocks.  (See the source code in `writ.js.md` for more details.)
 
 Syntax
 ------

--- a/test/test.js
+++ b/test/test.js
@@ -33,8 +33,7 @@ function test(md, out) {
   print('.');
 }
 
-exec('node writ.js "test/fixtures/*.md"', function() {
-  pairs(fixtures, test);
-  console.log();
-  cleanFixtures();
-});
+require('../writ.js').main(["", "", "test/fixtures/*.md"]);
+pairs(fixtures, test);
+console.log();
+cleanFixtures();

--- a/writ.js
+++ b/writ.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
-var cli = require('commander');
 var path = require('path');
-var glob = require('glob').sync;
 var marked = require('marked');
 function writ(file, outputDir) {
   var mdfile = read(file);
@@ -115,26 +113,41 @@ Source.prototype.resolveReferences = function(code) {
       : match;
   });
 }
-cli.usage('[options] <glob ...>')
+function main(argv) {
+
+  var cli = require ('commander');
+
+  cli.usage('[options] <glob ...>')
    .option('-d, --dir <path>', 'change output directory')
-   .parse(process.argv);
-if (!cli.args.length)
-  cli.help();
-var glob = require('glob').sync;
+   .parse(argv);
+  if (!cli.args.length)
+    cli.help();
+  var glob = require('glob').sync;
 
-var inputs = cli.args.reduce(function(out, fileglob) {
-  return out.concat(glob(fileglob));
-}, []);
+  var inputs = cli.args.reduce(function(out, fileglob) {
+    return out.concat(glob(fileglob));
+  }, []);
 
-if (!inputs.length)
-  error("Globs didn't match any source files");
-if (cli.dir && !fs.existsSync(cli.dir))
-  error('Directory does not exist: ' + JSON.stringify(cli.dir));
+  if (!inputs.length)
+    error("Globs didn't match any source files");
+  if (cli.dir && !fs.existsSync(cli.dir))
+    error('Directory does not exist: ' + JSON.stringify(cli.dir));
 
-var outputDir = cli.dir;
-inputs.forEach(function(file) {
-  writ(file, outputDir);
-});
+  var outputDir = cli.dir;
+  inputs.forEach(function(file) {
+    writ(file, outputDir);
+  });
+
+  return;
+}
+if (require.main === module) {
+  main(process.argv);
+} else module.exports = {
+  compile: compile,
+  writ: writ,
+  main: main,
+  Source: Source
+}
 function quoteRE(str) {
   return str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 }
@@ -153,6 +166,5 @@ function indent(text, leading) {
   return text.replace(/^.*\S+.*$/mg, leading + '$&');
 }
 function error(msg) {
-  console.error(msg);
-  process.exit(1);
+  throw new Error(msg);
 }


### PR DESCRIPTION
I'm making this pull request because I'd like to use writ in my projects, but I usually use `gulp` in my build processes and it's easier to integrate with gulp via code than via the command line, especially since `exec()` doesn't support *nix-style shell functionality on Windows.  So, to write a gulp plugin for writ, I need a programmatic API.

This pull request lightly tweaks the command line to make it a function instead of module-level code, and to detect whether it's being run from the command line.  If it's run from the command-line, it works the same as before.  But if it's require()'d from other code, it exports an API with `main(argv)`, `compile()`, `writ()`, and `Source`.

I plan to use `compile()` to implement the gulp plugin, but the rest seemed useful, especially when I found I needed to invoke the CLI programmatically to run the test suite on Windows.  ;-)

Anyway, let me know what you think!

